### PR TITLE
refactor: replace fmt.Print* with log/slog for structured logging

### DIFF
--- a/cmd/lapp/analyze.go
+++ b/cmd/lapp/analyze.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -47,7 +47,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read all lines
-	fmt.Fprintf(os.Stderr, "Reading logs...\n")
+	slog.Info("Reading logs...")
 	lines, err := readLines(logFile)
 	if err != nil {
 		return errors.Errorf("read log file: %w", err)
@@ -61,7 +61,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	for i, m := range merged {
 		mergedLines[i] = m.Content
 	}
-	fmt.Fprintf(os.Stderr, "Read %d lines, merged into %d entries\n", len(lines), len(mergedLines))
+	slog.Info("Read lines", "lines", len(lines), "merged_entries", len(mergedLines))
 
 	config := analyzer.Config{
 		APIKey: apiKey,
@@ -73,7 +73,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println(result)
+	slog.Info(result)
 	return nil
 }
 

--- a/cmd/lapp/debug.go
+++ b/cmd/lapp/debug.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/go-errors/errors"
@@ -41,7 +41,7 @@ files (raw.log, summary.txt, errors.txt) in a local directory for inspection.`,
 func runDebugWorkspace(cmd *cobra.Command, args []string) error {
 	logFile := args[0]
 
-	fmt.Fprintf(os.Stderr, "Reading logs...\n")
+	slog.Info("Reading logs...")
 	lines, err := readLines(logFile)
 	if err != nil {
 		return errors.Errorf("read log file: %w", err)
@@ -55,7 +55,7 @@ func runDebugWorkspace(cmd *cobra.Command, args []string) error {
 	for i, m := range merged {
 		mergedLines[i] = m.Content
 	}
-	fmt.Fprintf(os.Stderr, "Read %d lines, merged into %d entries\n", len(lines), len(mergedLines))
+	slog.Info("Read lines", "lines", len(lines), "merged_entries", len(mergedLines))
 
 	outDir := debugWorkspaceOutput
 	if outDir == "" {
@@ -74,7 +74,7 @@ func runDebugWorkspace(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("drain parser: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Parsing %d entries...\n", len(mergedLines))
+	slog.Info("Parsing entries", "count", len(mergedLines))
 	if err := drainParser.Feed(mergedLines); err != nil {
 		return errors.Errorf("drain feed: %w", err)
 	}
@@ -87,8 +87,7 @@ func runDebugWorkspace(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("build workspace: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Workspace created at: %s\n", outDir)
-	fmt.Println(outDir)
+	slog.Info("Workspace created", "dir", outDir)
 	return nil
 }
 
@@ -130,12 +129,12 @@ func runDebugRun(cmd *cobra.Command, args []string) error {
 		Model:  debugRunModel,
 	}
 
-	fmt.Fprintf(os.Stderr, "Running agent on workspace: %s\n", workDir)
+	slog.Info("Running agent on workspace", "dir", workDir)
 	result, err := analyzer.RunAgent(cmd.Context(), config, workDir, question)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(result)
+	slog.Info(result)
 	return nil
 }

--- a/cmd/lapp/ingest.go
+++ b/cmd/lapp/ingest.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
@@ -97,9 +97,12 @@ func runIngest(cmd *cobra.Command, args []string, model string) error {
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "Ingested %d lines, discovered %d patterns (%d with 2+ matches)\n",
-		len(lines), templateCount, patternCount)
-	fmt.Fprintf(os.Stderr, "Database: %s\n", dbPath)
+	slog.Info("Ingestion complete",
+		"lines", len(lines),
+		"templates", templateCount,
+		"patterns_with_2+_matches", patternCount,
+	)
+	slog.Info("Database stored", "path", dbPath)
 	return nil
 }
 
@@ -148,7 +151,7 @@ func discoverAndSavePatterns(
 	// Build labeler inputs with sample lines from in-memory data
 	inputs := buildLabelInputs(filtered, lines)
 
-	fmt.Fprintf(os.Stderr, "Labeling %d patterns...\n", len(inputs))
+	slog.Info("Labeling patterns", "count", len(inputs))
 
 	labels, err := semantic.Label(ctx, labelCfg, inputs)
 	if err != nil {

--- a/cmd/lapp/templates.go
+++ b/cmd/lapp/templates.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"log/slog"
 
 	"github.com/go-errors/errors"
 	"github.com/spf13/cobra"
@@ -45,8 +45,6 @@ func runTemplates(cmd *cobra.Command, _ []string) error {
 	}
 
 	if hasLabels {
-		fmt.Printf("%-12s %-6s %-22s %-6s %s\n", "ID", "TYPE", "SEMANTIC_ID", "COUNT", "DESCRIPTION")
-		fmt.Println("------------ ------ ---------------------- ------ ----------------------------------------")
 		for _, ts := range summaries {
 			semanticID := ts.SemanticID
 			if semanticID == "" {
@@ -60,17 +58,26 @@ func runTemplates(cmd *cobra.Command, _ []string) error {
 			if pType == "" {
 				pType = "-"
 			}
-			fmt.Printf("%-12s %-6s %-22s %-6d %s\n", ts.PatternUUIDString, pType, semanticID, ts.Count, desc)
+			slog.Info("template",
+				"id", ts.PatternUUIDString,
+				"type", pType,
+				"semantic_id", semanticID,
+				"count", ts.Count,
+				"description", desc,
+			)
 		}
 	} else {
-		fmt.Printf("%-12s %-6s %-6s %s\n", "ID", "TYPE", "COUNT", "PATTERN")
-		fmt.Println("------------ ------ ------ ----------------------------------------")
 		for _, ts := range summaries {
 			pType := ts.PatternType
 			if pType == "" {
 				pType = "-"
 			}
-			fmt.Printf("%-12s %-6s %-6d %s\n", ts.PatternUUIDString, pType, ts.Count, ts.Pattern)
+			slog.Info("template",
+				"id", ts.PatternUUIDString,
+				"type", pType,
+				"count", ts.Count,
+				"pattern", ts.Pattern,
+			)
 		}
 	}
 	return nil

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -73,7 +74,7 @@ func Analyze(ctx context.Context, config Config, lines []string, question string
 		return "", errors.Errorf("drain parser: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Parsing %d lines...\n", len(lines))
+	slog.Info("Parsing lines", "count", len(lines))
 	if err := drainParser.Feed(lines); err != nil {
 		return "", errors.Errorf("drain feed: %w", err)
 	}
@@ -98,7 +99,7 @@ func RunAgent(ctx context.Context, config Config, workDir, question string) (str
 		return "", errors.Errorf("resolve workspace dir: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "Analyzing with model %s...\n", config.Model)
+	slog.Info("Analyzing with model", "model", config.Model)
 
 	// Preflight check: verify API key works
 	if err := preflightCheck(ctx, config); err != nil {


### PR DESCRIPTION
Migrate all CLI output from fmt.Printf/Println/Fprintf to slog.Info/Warn
with structured key-value attributes for consistent, structured logging
across all commands. Also fix fmt.Errorf usages to use errors.Errorf and
exclude pkg/multiline (vendored copy-as-is code) from golangci-lint.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":""}
```
-->
