### PR TITLE
feat: increase Drain tree depth from 4 to 30

### DIFF
--- a/pkg/pattern/drain.go
+++ b/pkg/pattern/drain.go
@@ -23,7 +23,7 @@ type DrainParser struct {
 // NewDrainParser creates a DrainParser with default Drain parameters.
 func NewDrainParser() (*DrainParser, error) {
 	d, err := drain3.NewDrain(
-		drain3.WithDepth(4),
+		drain3.WithDepth(30),
 		drain3.WithSimTh(0.4),
 		drain3.WithExtraDelimiter([]string{"|", "=", ","}),
 	)


### PR DESCRIPTION
Matches Loki's default (LogClusterDepth: 30). Higher depth means the prefix tree routes more precisely, reducing the number of candidate clusters that need similarity comparison at leaf nodes.

Ref: https://github.com/grafana/loki/tree/main/pkg/pattern/drain