### PR TITLE
feat: decouple discovery from add-log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,9 @@ go test -v -run TestFunctionName ./pkg/pattern/
 
 ```bash
 go run ./cmd/lapp/ workspace create <topic>
-go run ./cmd/lapp/ workspace add-log --topic <topic> <logfile> [--model <model>]
-go run ./cmd/lapp/ workspace add-log --topic <topic> --stdin [--model <model>]
+go run ./cmd/lapp/ workspace add-log --topic <topic> <logfile>
+go run ./cmd/lapp/ workspace add-log --topic <topic> --stdin
+go run ./cmd/lapp/ workspace discover --topic <topic> [--model <model>]
 go run ./cmd/lapp/ workspace analyze --topic <topic> [question] [--model <model>]
 go run ./cmd/lapp/ web [--addr 127.0.0.1:0]
 ```
@@ -35,21 +36,21 @@ Topic names are sanitized to lower-kebab-case. Workspaces live under `~/.lapp/wo
 ## Architecture
 
 ```
-cmd/lapp/                CLI entrypoint (cobra commands: workspace create/add-log/analyze)
+cmd/lapp/                CLI entrypoint (cobra commands: workspace create/add-log/discover/analyze)
 pkg/logsource/           Read log files → channel of LogLine
 pkg/multiline/           Detect log entry boundaries, merge continuation lines
 pkg/pattern/             Drain-based log pattern discovery and template matching
 pkg/semantic/            LLM-based semantic labeling of Drain patterns
 pkg/workspace/           DiscoveryRun execution and run-scoped file writer
-pkg/store/               DuckDB storage primitives (not yet on the CLI add-log path)
+pkg/store/               DuckDB storage primitives (not yet on the CLI discovery path)
 pkg/config/              Model resolution (flag → $MODEL_NAME → default)
 pkg/analyzer/            Agentic log analysis via eino ADK + ACP providers
 integration_test/        Integration tests against Loghub-2.0 datasets
 ```
 
-### DiscoveryRun (add-log)
+### DiscoveryRun (discover)
 
-Each `add-log` copies a log file, then starts a DiscoveryRun: reads ALL files in `logs/`, runs fresh Drain + semantic labeling, and writes run-scoped `patterns/` and `notes/`.
+`add-log` is a pure copy into `logs/` and never triggers discovery. Each `workspace discover` starts a DiscoveryRun: reads ALL files in `logs/`, runs fresh Drain + semantic labeling, and writes run-scoped `patterns/` and `notes/`.
 When `lapp web` starts, it marks any previous `QUEUED` or `RUNNING` DiscoveryRuns as failed because those local workers no longer exist.
 DiscoveryRun records persist structured `progress` and `error` fields; frontend code renders those facts into user-facing text.
 
@@ -75,7 +76,7 @@ Runs an eino ADK agent (15 max iterations) with filesystem tools (grep, read_fil
 
 ## Environment Variables
 
-- `OPENROUTER_API_KEY`: Required for semantic labeling in `workspace add-log`
+- `OPENROUTER_API_KEY`: Required for semantic labeling in `workspace discover`
 - `MODEL_NAME`: Override default LLM model (default: `google/gemini-3-flash-preview`)
 - ACP provider credentials/login: Required for `workspace analyze` through the selected provider
 - `.env` file is auto-loaded via godotenv

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,6 +11,22 @@ _Avoid_: Project, incident
 **Dashboard**:
 The main entry screen where people find and open investigation workspaces. It is an entry point, not the primary analysis surface.
 
+**Run**:
+One tracked background execution inside a workspace, with a queued, running, then succeeded or failed lifecycle. DiscoveryRun and ImportRun are kinds of Run. Runs never trigger each other; people decide what to run next.
+_Avoid_: Task, job
+
 **DiscoveryRun**:
-One execution that turns the current log files in a workspace into discovered patterns and generated investigation material. It covers both the first discovery and later rediscovery after log files change.
+One execution that turns the current log files in a workspace into discovered patterns and generated investigation material. It covers both the first discovery and later rediscovery after log files change. It starts only when a person asks for it.
 _Avoid_: Build, rebuild
+
+**ImportRun**:
+One execution that pulls logs from an external provider using a query and time range, and materializes the result as a log file in the workspace. The workspace keeps the import record for provenance and re-pull; there is no persistent connection to the provider.
+_Avoid_: Sync, connection, integration, LogImport
+
+**Provider**:
+An external logging service LAPP can import from, such as GCP Cloud Logging or Vercel. LAPP uses credentials already present on the machine and never manages provider authentication itself.
+_Avoid_: Source, backend
+
+**Projection**:
+The text line derived from a structured log entry for pattern discovery. Discovery reads the projection; investigation material keeps the full structured entry.
+_Avoid_: Flattening, rendering

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ go run ./cmd/lapp/ workspace create app-incident
 # Start the local web app
 go run ./cmd/lapp/ web
 
-# Add logs to the workspace and run discovery
+# Add logs to the workspace (pure copy, no discovery)
 go run ./cmd/lapp/ workspace add-log --topic app-incident /var/log/syslog
+
+# Run discovery over all log files in the workspace
+go run ./cmd/lapp/ workspace discover --topic app-incident
 
 # AI-powered analysis (agent backend via ACP provider)
 go run ./cmd/lapp/ workspace analyze --topic app-incident "why are there connection timeouts?" --acp claude
@@ -33,7 +36,9 @@ The current CLI product is a structured file workspace under `~/.lapp/workspaces
 
 ```
 workspace add-log
-  -> copy input into logs/
+  -> copy input into logs/ (nothing else)
+
+workspace discover
   -> read all files in logs/
   -> merge multiline entries
   -> discover repeated Drain patterns
@@ -64,7 +69,7 @@ DiscoveryRuns are one-time local tasks. If `lapp web` starts and finds a previou
 
 ## Environment Variables
 
-- `OPENROUTER_API_KEY`: Required for semantic labeling in `workspace add-log`
+- `OPENROUTER_API_KEY`: Required for semantic labeling in `workspace discover`
 - `MODEL_NAME`: Override default LLM model (default: `google/gemini-3-flash-preview`)
 - Provider-specific auth for ACP agent CLI (for example Claude/Codex/Gemini CLI login credentials)
 - `.env` file is auto-loaded
@@ -75,14 +80,15 @@ DiscoveryRuns are one-time local tasks. If `lapp web` starts and finds a previou
 |---|---|
 | `workspace create <topic>` | Create a workspace under `~/.lapp/workspaces/` |
 | `workspace list` | List all workspace topics |
-| `workspace add-log --topic <topic> <file>` | Add log file and run discovery |
+| `workspace add-log --topic <topic> <file>` | Copy a log file into the workspace |
+| `workspace discover --topic <topic>` | Run pattern discovery over all log files |
 | `workspace analyze --topic <topic> [question]` | Run AI analysis (`--acp claude|codex|gemini`) |
 
 ## Event Schema
 
 The initial normalized event contract is defined in [proto/lapp/event/v1/event.proto](proto/lapp/event/v1/event.proto) and documented in [docs/event-schema-v1.md](docs/event-schema-v1.md). Representative fixtures live under `fixtures/events/v1/` for JSON, logfmt, `key=value`, and plain text logs.
 
-The event parser and DuckDB store packages are library-level building blocks. They are covered by tests and integration tests, but `workspace add-log` currently writes DiscoveryRun results directly into the local workspace instead of persisting through DuckDB first.
+The event parser and DuckDB store packages are library-level building blocks. They are covered by tests and integration tests, but `workspace discover` currently writes DiscoveryRun results directly into the local workspace instead of persisting through DuckDB first.
 
 ## Development
 

--- a/cmd/lapp/workspace.go
+++ b/cmd/lapp/workspace.go
@@ -46,6 +46,7 @@ func workspaceCmd() *cobra.Command {
 	cmd.AddCommand(workspaceCreateCmd())
 	cmd.AddCommand(workspaceListCmd())
 	cmd.AddCommand(workspaceAddLogCmd())
+	cmd.AddCommand(workspaceDiscoverCmd())
 	cmd.AddCommand(workspaceAnalyzeCmd())
 	return cmd
 }
@@ -146,23 +147,21 @@ Use ` + "`lapp workspace add-log --topic " + topic + " <logfile>`" + ` to add lo
 	return nil
 }
 
-var addLogModel string
 var addLogStdin bool
 var addLogTopic string
 
 func workspaceAddLogCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-log [logfile]",
-		Short: "Add a log file to the workspace and start discovery",
-		Long: `Copy a log file into the workspace's logs/ directory, then run the full
-DiscoveryRun flow (Drain clustering + semantic labeling) to generate run-scoped results.
+		Short: "Copy a log file into the workspace",
+		Long: `Copy a log file into the workspace's logs/ directory.
 
-Requires OPENROUTER_API_KEY environment variable.`,
+This does not run discovery. Run 'lapp workspace discover --topic <topic>' afterwards
+to discover patterns over all log files in the workspace.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runWorkspaceAddLog,
 	}
 	cmd.Flags().StringVar(&addLogTopic, "topic", "", "workspace topic (required)")
-	cmd.Flags().StringVar(&addLogModel, "model", "", "override LLM model")
 	cmd.Flags().BoolVar(&addLogStdin, "stdin", false, "read log from stdin")
 	_ = cmd.MarkFlagRequired("topic")
 	return cmd
@@ -180,24 +179,77 @@ func runWorkspaceAddLog(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("not a workspace: %s (no logs/ directory)%s", dir, hint)
 	}
 
-	apiKey := os.Getenv("OPENROUTER_API_KEY")
-	if apiKey == "" {
-		return errors.New("OPENROUTER_API_KEY environment variable is required")
-	}
-
-	ctx, span := otel.Tracer("lapp/cmd").Start(cmd.Context(), "cmd.WorkspaceAddLog")
+	_, span := otel.Tracer("lapp/cmd").Start(cmd.Context(), "cmd.WorkspaceAddLog")
 	defer span.End()
 
 	if err := copyLogToWorkspace(dir, args, span.SetAttributes); err != nil {
 		return err
 	}
 
+	topic := filepath.Base(dir)
+	fmt.Printf("Log added. Discovery has not run yet.\nRun it with:\n\n  lapp workspace discover --topic %s\n", topic)
+	span.SetStatus(codes.Ok, "")
+	return nil
+}
+
+var discoverModel string
+var discoverTopic string
+
+func workspaceDiscoverCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "discover",
+		Short: "Run pattern discovery over all log files in the workspace",
+		Long: `Start a DiscoveryRun over ALL current log files in the workspace:
+Drain clustering + LLM semantic labeling, writing run-scoped results under
+discovery-runs/<run-id>/.
+
+Requires OPENROUTER_API_KEY environment variable.`,
+		Args: cobra.NoArgs,
+		RunE: runWorkspaceDiscover,
+	}
+	cmd.Flags().StringVar(&discoverTopic, "topic", "", "workspace topic (required)")
+	cmd.Flags().StringVar(&discoverModel, "model", "", "override LLM model")
+	_ = cmd.MarkFlagRequired("topic")
+	return cmd
+}
+
+func runWorkspaceDiscover(cmd *cobra.Command, _ []string) error {
+	dir, err := topicToDir(discoverTopic)
+	if err != nil {
+		return err
+	}
+
+	// Validate workspace exists
+	if _, err := os.Stat(filepath.Join(dir, "logs")); os.IsNotExist(err) {
+		hint := availableWorkspacesHint()
+		return errors.Errorf("not a workspace: %s (no logs/ directory)%s", dir, hint)
+	}
+
+	topic := filepath.Base(dir)
+	logFiles, err := workspace.ListLogFiles(dir)
+	if err != nil {
+		return errors.Errorf("list log files: %w", err)
+	}
+	if len(logFiles) == 0 {
+		return errors.Errorf("workspace %q has no log files; add one with `lapp workspace add-log --topic %s <logfile>`", topic, topic)
+	}
+
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		return errors.New("OPENROUTER_API_KEY environment variable is required")
+	}
+
+	ctx, span := otel.Tracer("lapp/cmd").Start(cmd.Context(), "cmd.WorkspaceDiscover")
+	defer span.End()
+
 	result, err := workspace.Discover(ctx, workspace.DiscoveryConfig{
 		Dir:    dir,
 		APIKey: apiKey,
-		Model:  addLogModel,
+		Model:  discoverModel,
 	})
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
@@ -289,7 +341,7 @@ func runWorkspaceAnalyze(cmd *cobra.Command, args []string) error {
 	}
 	latestSuccess := workspace.LatestSuccessfulDiscoveryRun(records)
 	if latestSuccess == nil {
-		return errors.Errorf("no successful discovery run found for workspace %q; run `lapp workspace add-log --topic %s <logfile>` first", filepath.Base(absDir), filepath.Base(absDir))
+		return errors.Errorf("no successful discovery run found for workspace %q; run `lapp workspace discover --topic %s` first", filepath.Base(absDir), filepath.Base(absDir))
 	}
 
 	tapePath := filepath.Join(absDir, ".tape.jsonl")

--- a/docs/adr/0004-external-logs-imported-as-snapshots.md
+++ b/docs/adr/0004-external-logs-imported-as-snapshots.md
@@ -1,0 +1,12 @@
+# External logs are imported as snapshots, not live connections
+
+LAPP can pull logs from external providers (first: GCP Cloud Logging), but an ImportRun always materializes the result as a log file inside the workspace, after which the pipeline treats it exactly like an uploaded file. There is no persistent connection entity, no continuous tailing, and no LAPP-managed provider authentication: each import is a one-off recorded action, and credentials are whatever already exists on the machine (ADC for GCP).
+
+**Considered Options**
+
+- Snapshot import: pull a query + time range, land it as a local file
+- Live connection: workspace holds a remote source, discovery and analysis query the provider on demand
+
+**Consequences**
+
+ADR 0001 (local workspaces as source of truth) stays intact, and investigations remain reproducible after the provider's retention window expires. The ImportRun record (provider, project, filter, time range, truncation flag) is the provenance for the imported file and the basis for re-pulling with a different time range; recall of past queries across workspaces is a derived view over these records, not a stored entity. Continuous-monitoring use cases are explicitly out of scope.

--- a/docs/adr/0005-runs-are-decoupled-and-manually-triggered.md
+++ b/docs/adr/0005-runs-are-decoupled-and-manually-triggered.md
@@ -1,0 +1,13 @@
+# Runs are decoupled and manually triggered
+
+ImportRun and DiscoveryRun are independent Runs in a workspace; no Run ever triggers another. Adding logs (upload or import) never starts discovery — the person explicitly starts a DiscoveryRun when they are done gathering logs. This reverses the original add-log behavior, which automatically started a DiscoveryRun after copying the file.
+
+**Considered Options**
+
+- Auto-trigger with coalescing (import completion enqueues discovery unless one is pending)
+- Auto-trigger with a per-action opt-out flag
+- Manual only
+
+**Consequences**
+
+Investigations that gather several log batches (multiple imports, multiple uploads, or a mix) run discovery once instead of once per file. The CLI gains an explicit `workspace discover` command and `add-log` becomes a pure copy. Web UI needs an explicit "run discovery" affordance, and a freshly-added log file can sit undiscovered until the user asks — that staleness is accepted as the price of a single, predictable rule.

--- a/docs/adr/0006-ndjson-log-files-with-message-projection.md
+++ b/docs/adr/0006-ndjson-log-files-with-message-projection.md
@@ -1,0 +1,16 @@
+# Structured logs are stored as NDJSON and discovered via message projection
+
+Log files can be NDJSON (one JSON entry per line) as well as plain text, detected per file by the pipeline — the capability belongs to the pipeline, not to any import provider, so hand-uploaded NDJSON files get the same treatment as imported ones. Imported GCP entries land in a fixed envelope: `{"ts": ..., "severity": ..., "payload": {...}}` with the jsonPayload nested untouched (textPayload becomes `payload.message`); provider metadata such as labels, trace, and resource stays in the ImportRun record, not in the log lines.
+
+For pattern discovery, JSON entries are projected to a text line rather than fed to Drain whole: the first string field among `payload.message`, `msg`, `log`, `error` becomes the projection (`<severity> <message>`); if none exists, the compact payload JSON is the fallback. Timestamps are excluded from the projection to keep Drain templates clean.
+
+**Considered Options**
+
+- Flatten everything to text at import time (structure lost)
+- NDJSON storage, discovery on compact-JSON lines (structure kept, dirty templates)
+- NDJSON storage with message projection (chosen)
+- JSON-native pattern discovery by structure/key-set (a second discovery engine — deferred, not rejected)
+
+**Consequences**
+
+The envelope and the projection rule are part of the workspace file contract (ADR 0001). Payload fields are never flattened to the top level, so user fields named `severity` or `ts` cannot collide with the envelope. Analysis agents can query structure with jq-style tools instead of grepping flattened text. If real usage shows dirty templates for payloads without a message-like field, the projection rule is the extension point.


### PR DESCRIPTION
## Problem

add-log automatically started a DiscoveryRun after every file, so gathering
several log files ran discovery repeatedly and wasted each intermediate run.
It also required OPENROUTER_API_KEY just to copy a file. The web API was
already decoupled (UploadLogFile does not trigger discovery), leaving the CLI
with different semantics.

## Solution

Runs never trigger each other (ADR 0005). add-log becomes a pure copy and a
new `workspace discover` command starts one DiscoveryRun on demand over all
current log files.

## Major Changes

- CLI
  - `workspace add-log` no longer starts discovery and no longer needs
    OPENROUTER_API_KEY; it prints the exact `workspace discover` command to
    run next
  - new `workspace discover --topic <t> [--model <m>]` command; the
    OPENROUTER_API_KEY pre-check moves here; clear errors for unknown
    workspace, empty workspace, and missing key
- Docs
  - ADR 0004/0005/0006 record the log import feature decisions (snapshot
    imports, decoupled manual runs, NDJSON with message projection); glossary
    adds Run, ImportRun, Provider, Projection
  - CLAUDE.md and README reflect the new two-step flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI workflow and when discovery runs (users must discover explicitly); discovery execution is relocated, not reimplemented, but mis-running analyze before discover is a new footgun.
> 
> **Overview**
> **`workspace add-log` only copies logs into `logs/`** — it no longer starts a DiscoveryRun, drops the `--model` flag, and does not require `OPENROUTER_API_KEY`. After a successful copy it prints the exact `lapp workspace discover --topic …` command to run next.
> 
> **New `workspace discover --topic <t> [--model <m>]`** owns the former add-log discovery path: validates the workspace has log files, requires `OPENROUTER_API_KEY`, calls `workspace.Discover`, and records OpenTelemetry on `cmd.WorkspaceDiscover`. **`workspace analyze`** error text now tells users to run `discover` instead of `add-log` when no successful discovery exists.
> 
> **Documentation** updates README/CLAUDE for the two-step flow and adds ADR 0005 (manual, decoupled runs), plus ADR 0004/0006 and CONTEXT glossary terms (Run, ImportRun, Provider, Projection) for upcoming import/NDJSON work — those ADRs are not implemented in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc42fb48f0a263a70deb67f6b564d508b2d0562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->